### PR TITLE
para-noel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.vscode
+tests/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,10 +109,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "libc"
@@ -110,11 +165,23 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "noel"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "libc",
+ "num_cpus",
+ "rayon",
  "thiserror",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -133,6 +200,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noel"
-version = "0.1.0"
+version = "0.2.1"
 authors = ["alejandrogzi <jose.gonzalesdezavala1@unmsm.edu.pe>"]
 edition = "2021"
 license = "MIT"
@@ -15,6 +15,8 @@ categories = ["command-line-utilities", "science"]
 clap = { version = "4.4.2", features = ["derive"] }
 libc = "0.2.149"
 thiserror = "1.0.50"
+rayon = "1.8.0"
+num_cpus = "1.13.0"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![version-badge](https://img.shields.io/badge/version-0.1.0-green)
+![version-badge](https://img.shields.io/badge/version-0.2.0-green)
 ![Crates.io](https://img.shields.io/crates/v/noel)
 ![GitHub](https://img.shields.io/github/license/alejandrogzi/noel?color=blue)
 
@@ -15,7 +15,7 @@ Takes in a GTF/GFF file and outputs a .txt file with non-overlapping exon length
 
 ## Usage
 ``` rust
-Usage: noel[EXE] --i <GTF/GFF> --o <OUTPUT>
+Usage: noel --i <GTF/GFF> --o <OUTPUT>
 
 Arguments:
     --i <GTF/GFF>: GTF/GFF file
@@ -44,7 +44,7 @@ to build noel from this repo, do:
 
 ## Library
 to include noel as a library and use it within your project follow these steps:
-1. include `noel = 0.1.0` or `noel = "*"` under `[dependencies]` in your `Cargo.toml` file or just run `cargo add noel` from the command line
+1. include `noel = 0.2.0` or `noel = "*"` under `[dependencies]` in your `Cargo.toml` file or just run `cargo add noel` from the command line
 2. the library name is `noel`, to use it just write:
 
     ``` rust
@@ -57,11 +57,11 @@ to include noel as a library and use it within your project follow these steps:
 3. invoke
     ``` rust
     let exons: HashMap<String, Vec<(u32, u32)>> = noel_reader(input: &PathBuf)?
-    let lengths: HashMap<String, u32> = noel(exons)
+    let lengths: Vec<(String, u32)> = noel(exons)
     ```
 4. you will end with a HashMap, where each gene name (gene_id) is a key to its length
     ```text
-    {"ENSG00000261469": 533, "ENSG00000150990": 6908, "ENSG00000136490": 4751, "ENSG00000290760": 801}
+    [("ENSG00000261469": 533), ("ENSG00000150990": 6908), ("ENSG00000136490": 4751), ("ENSG00000290760": 801)]
     ```
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A small library for computing the number of base pairs in a gene
 //!
 //! to include noel as a library and use it within your project follow these steps:
-//! 1. include `noel = 0.1.0` or `noel = "*"` under `[dependencies]` in your `Cargo.toml` file or just run `cargo add noel` from the command line
+//! 1. include `noel = 0.2.1` or `noel = "*"` under `[dependencies]` in your `Cargo.toml` file or just run `cargo add noel` from the command line
 //! 2. the library name is `noel`, to use it just write:
 //! ``` rust
 //! use noel::{noel, noel_reader};
@@ -15,72 +15,90 @@
 //! let exons = noel_reader(input: &PathBuf)
 //! let lengths: HashMap<String, u32> = noel(exons: HashMap<String, Vec<(u32, u32)>>)
 //! ```
-//!
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use rayon::prelude::*;
 
 pub mod record;
 pub use record::*;
 
-pub fn noel(exons: HashMap<String, Vec<(u32, u32)>>) -> Option<HashMap<String, u32>> {
-    let mut genes = HashMap::new();
-    for (gene, exons) in exons.iter() {
-        let (min_start, max_end) = exons.iter().fold((u32::MAX, 0), |acc, &(start, end)| {
-            (acc.0.min(start), acc.1.max(end))
-        });
+pub fn get_lengths(exons: HashMap<String, Vec<(u32, u32)>>) -> Option<Vec<(String, u32)>> {
+    let lengths = exons
+        .into_par_iter()
+        .map(|(gene, exons)| {
+            let (min_start, max_end) = exons.iter().fold((u32::MAX, 0), |acc, &(start, end)| {
+                (acc.0.min(start), acc.1.max(end))
+            });
 
-        let mut bp = vec![0; (max_end - min_start + 1) as usize];
+            let mut bp = vec![0; (max_end - min_start + 1) as usize];
 
-        for &(start, end) in exons.iter() {
-            for i in (start - min_start)..(end - min_start + 1) {
-                bp[i as usize] = 1;
+            for &(start, end) in exons.iter() {
+                for i in (start - min_start)..(end - min_start + 1) {
+                    bp[i as usize] = 1;
+                }
             }
-        }
 
-        let total_bp: u32 = bp.iter().sum();
-        genes.insert(gene.clone(), total_bp);
-    }
-    Some(genes)
+            let total_bp: u32 = bp.iter().sum();
+            (gene, total_bp)
+        })
+        .collect::<Vec<(String, u32)>>();
+
+    Some(lengths)
 }
 
 pub fn noel_reader(input: &PathBuf) -> Option<HashMap<String, Vec<(u32, u32)>>> {
-    let rdr = read_gtf(input)?;
-    let mut exons: HashMap<String, Vec<(u32, u32)>> = HashMap::new();
+    let contents = reader(input).unwrap();
+    let records = parallel_parse(&contents).unwrap();
 
-    for line in rdr.lines() {
-        let line = line.unwrap();
-
-        if line.starts_with("#") {
-            continue;
-        }
-
-        match Record::new(line) {
-            Ok(record) => {
-                let (start, end, gene_id) = record.info();
+    let exons: HashMap<String, Vec<(u32, u32)>> = records
+        .into_par_iter()
+        .filter(|line| line.feature() == "exon") // Filter out non-exons
+        .fold(
+            || HashMap::new(),
+            |mut map, line| {
+                map.entry(line.gene_id)
+                    .or_insert_with(Vec::new)
+                    .push((line.start, line.end));
+                map
+            },
+        )
+        .reduce(
+            || HashMap::new(),
+            |mut exons, thread_map| {
+                for (key, value) in thread_map {
+                    exons.entry(key).or_insert_with(Vec::new).extend(value);
+                }
                 exons
-                    .entry(gene_id)
-                    .or_insert(Vec::new())
-                    .push((start, end));
-            }
-            Err(_) => continue,
-        }
-    }
+            },
+        );
+
     Some(exons)
 }
 
-pub fn read_gtf(input: &Path) -> Option<BufReader<File>> {
-    match input.extension() {
-        Some(ext) if ext == "gtf" || ext == "gff" || ext == "gff3" => {
-            let records = BufReader::new(File::open(input).unwrap());
-            Some(records)
-        }
-        _ => {
-            let err = "No gtf/gff file provided. Check the extension of your file.";
-            eprintln!("{} {}", "Error:", err);
-            None
-        }
-    }
+fn reader(file: &PathBuf) -> io::Result<String> {
+    let mut file = File::open(file)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
+}
+
+fn parallel_parse<'a>(s: &'a str) -> Result<Vec<Record>, NoelError> {
+    let records: Result<Vec<Record>, NoelError> = s
+        .par_lines()
+        .map(|line| match Record::new(line) {
+            Ok(record) => Ok(record),
+            Err(_) => Ok(Record {
+                feat: "".to_string(),
+                start: 0,
+                end: 0,
+                gene_id: "".to_string(),
+            }),
+        })
+        .collect();
+
+    return records;
 }

--- a/src/record/attr.rs
+++ b/src/record/attr.rs
@@ -10,7 +10,7 @@ pub struct Attribute {
 }
 
 impl Attribute {
-    pub fn parse(line: &String) -> Result<Attribute, CocoError> {
+    pub fn parse(line: &str) -> Result<Attribute, NoelError> {
         if !line.is_empty() {
             let mut attributes: HashMap<String, String> = HashMap::new();
             let bytes = line.as_bytes().iter().enumerate();
@@ -20,20 +20,20 @@ impl Attribute {
                 if *byte == b';' {
                     let word = &line[start..i];
                     if !word.is_empty() && word.starts_with("gene_id") {
-                        let (key, value) = get_pair(word).ok_or(CocoError::Parse)?;
+                        let (key, value) = get_pair(word).ok_or(NoelError::Parse)?;
                         attributes.insert(key, value);
                     }
                     start = i + 1;
                 }
             }
 
-            let gene_id = attributes.get("gene_id").ok_or(CocoError::Invalid);
+            let gene_id = attributes.get("gene_id").ok_or(NoelError::Invalid);
 
             Ok(Attribute {
                 gene_id: gene_id?.to_string(),
             })
         } else {
-            Err(CocoError::Empty)
+            Err(NoelError::Empty)
         }
     }
 
@@ -74,7 +74,7 @@ fn get_gene(gene: &str, sep: &str) -> Option<String> {
 }
 
 #[derive(Error, Debug, PartialEq)]
-pub enum CocoError {
+pub enum NoelError {
     #[error("Empty line")]
     Empty,
     #[error("Invalid GTF line")]
@@ -111,7 +111,7 @@ mod tests {
         let input = "transcript_id \"XYZ\"; exon_number \"1\";".to_string();
         let result = Attribute::parse(&input);
 
-        assert_eq!(result.unwrap_err(), CocoError::Invalid);
+        assert_eq!(result.unwrap_err(), NoelError::Invalid);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds parallel functionality to noel. Changes the behavior of the readers and length calculator for a new set of parallel readers and threat-distributed length calculations, to finally merge them. Note that now, that 1) noel function is not longer called `noel::noel(args)` but instead called `noel::get_lengths(args)`; and 2) the output data structure of `noel::get_lengths(args)` is `Vec<(String, u32)>`. Some additional changes have been made to the record/attribute structs, changing the byte-to-byte split for the common split function. All these changes improve by x2 the time of noel (3.6s -> 1.7s).